### PR TITLE
Fix link for RO-Crate OME Use Cases

### DIFF
--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -4,7 +4,7 @@
 
 * [**OME-NGFF-Challenge**](https://ome.github.io/ome2024-ngff-challenge/): 422.89 TB of distributed public bioimage data including RO-Crate-compliant metadata.
 * [**NGFF-RFC**](https://ngff.openmicroscopy.org/rfc): discuss and capture high-level decisions within the NGFF community.
-* [**RO-Crate OME Use Cases**](https://research-object.org/ro-crate): overview the uses of RO-Crate in the Open Microscopy Environment.
+* [**RO-Crate OME Use Cases**](https://www.researchobject.org/ro-crate/ome): overview the uses of RO-Crate in the Open Microscopy Environment.
 
 ## Events
 


### PR DESCRIPTION
Updated the link for RO-Crate OME Use Cases to the correct URL.

Bad URL, sorry! thank you @joshmoore for spotting it 